### PR TITLE
Fix for settings bug

### DIFF
--- a/KerbalLaunchFailure/KLFSettings.cs
+++ b/KerbalLaunchFailure/KLFSettings.cs
@@ -206,12 +206,12 @@ namespace KerbalLaunchFailure
         public bool LoadSettings()
         {
             
-            initialFailureProbability = (float)HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().initialFailureProbability;
-            expPartFailureProbability = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().expPartFailureProbability;
+            initialFailureProbability = (float)HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().initialFailureProb;
+            expPartFailureProbability = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().expPartFailureProb;
             maxFailureAltitudePercentage = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().maxFailureAltitudePerc;
             propagationChanceDecreases = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().propagationChanceDecreases;
-            failurePropagateProbability = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().failurePropagateProbability;
-            delayBetweenPartFailures = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().delayBetweenPartFailures;
+            failurePropagateProbability = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().failurePropagateProb;
+            delayBetweenPartFailures = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams>().delayBetweenPartFail;
             autoAbort = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams2>().autoAbort;
             autoAbortDelay = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams2>().autoAbortDelay;
             preFailureWarningTime = HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams2>().preFailureWarningTime;

--- a/KerbalLaunchFailure/KerbalLaunchFailure.cs
+++ b/KerbalLaunchFailure/KerbalLaunchFailure.cs
@@ -319,7 +319,7 @@ namespace KerbalLaunchFailure
             failure = new Failure();
             if (HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams2>().allowEngineUnderthrust)
             {
-                failure.overThrust = KLFUtils.RNG.NextDouble() >= HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams2>().engineUnderthrustProbability;
+                failure.overThrust = KLFUtils.RNG.NextDouble() >= HighLogic.CurrentGame.Parameters.CustomParams<KLFCustomParams2>().engineUnderthrustProb;
             }
             else
                 failure.overThrust =true;


### PR DESCRIPTION
Fix settings bug that is grabbing the UI integer values instead of the float values for initial failure probability, engine underthrust probability, exponential failure probability, failure propagation, and delay between part failure.  This should fix the issue where people are experiencing failures on every launch.